### PR TITLE
feat: add core JPA entities

### DIFF
--- a/src/main/java/com/example/autotest_backend/model/Choice.java
+++ b/src/main/java/com/example/autotest_backend/model/Choice.java
@@ -1,0 +1,30 @@
+package com.example.autotest_backend.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "choices")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Choice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String choiceText;
+
+    @Column(nullable = false)
+    private boolean correct;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    @Setter(AccessLevel.PROTECTED)
+    private Question question;
+}

--- a/src/main/java/com/example/autotest_backend/model/Question.java
+++ b/src/main/java/com/example/autotest_backend/model/Question.java
@@ -1,0 +1,50 @@
+package com.example.autotest_backend.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Entity
+@Table(name = "questions")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String questionText;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private QuestionStatus status = QuestionStatus.PENDING;
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Setter(AccessLevel.NONE)
+    private List<Choice> choices = new ArrayList<>();
+
+    public List<Choice> getChoices() {
+        return Collections.unmodifiableList(choices);
+    }
+
+    public void addChoice(Choice c) {
+        choices.add(c);
+        c.setQuestion(this);
+    }
+
+    public void removeChoice(Choice c) {
+        choices.remove(c);
+        c.setQuestion(null);
+    }
+
+}

--- a/src/main/java/com/example/autotest_backend/model/QuestionStatus.java
+++ b/src/main/java/com/example/autotest_backend/model/QuestionStatus.java
@@ -1,0 +1,8 @@
+package com.example.autotest_backend.model;
+
+public enum QuestionStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}
+

--- a/src/main/java/com/example/autotest_backend/model/User.java
+++ b/src/main/java/com/example/autotest_backend/model/User.java
@@ -1,0 +1,26 @@
+package com.example.autotest_backend.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+}

--- a/src/main/java/com/example/autotest_backend/model/UserQuestion.java
+++ b/src/main/java/com/example/autotest_backend/model/UserQuestion.java
@@ -1,0 +1,30 @@
+package com.example.autotest_backend.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_questions", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "question_id"})
+})
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserQuestion {
+
+    @Id
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    @Setter(lombok.AccessLevel.NONE)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Setter(AccessLevel.PROTECTED)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    @Setter(AccessLevel.PROTECTED)
+    private Question question;
+}

--- a/src/main/java/com/example/autotest_backend/model/UserQuestion.java
+++ b/src/main/java/com/example/autotest_backend/model/UserQuestion.java
@@ -14,7 +14,7 @@ import lombok.*;
 public class UserQuestion {
 
     @Id
-    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Setter(lombok.AccessLevel.NONE)
     private Long id;
 

--- a/src/main/java/com/example/autotest_backend/model/UserRole.java
+++ b/src/main/java/com/example/autotest_backend/model/UserRole.java
@@ -1,0 +1,6 @@
+package com.example.autotest_backend.model;
+
+public enum UserRole {
+    STUDENT,
+    TEACHER
+}


### PR DESCRIPTION
# Pull Request

## Summary
<!-- Brief summary of changes introduced -->
This PR introduces the core JPA entities for the AutoTest MVP.

## Related Issue
<!-- Link the related issue -->
Closes #1

## Changes
<!-- List the main changes made -->
- Added `User` entity with email and role
- Added `Question` entity with text, status, and choices
- Added `Choice` entity with text and `correct` flag
- Added `UserQuestion` entity to record questions answered by users
- Added enums `UserRole` and `QuestionStatus`
- Configured relationships between entities (cascade, orphanRemoval, helper methods)

## Design Decisions
<!-- Explain relevant design, architecture, or domain decisions -->
- `UserQuestion` was chosen instead of a direct Many-to-Many to allow future extensions (attempts, metrics)
- `Choice` does not have its own repository; it is managed through `Question` (cascade)
- IDs are auto-generated and have no public setters
- Collections are protected and accessed via helper methods
- Model designed to scale without breaking the API

## Scope
<!-- What is included and what is not in this PR -->
Includes **only the model layer**:
- JPA entities
- Relationships and helper methods
- Enums

Does not include: repositories, services, or controllers.

## Testing
<!-- How it was tested, if applicable -->
- Successfully compiles

## Notes
<!-- Additional information, warnings, reminders -->
- This PR serves as the foundation for future repositories and services
