### PR TITLE
feat: add core JPA repositories

### DIFF
--- a/src/main/java/com/example/autotest_backend/repository/QuestionRepository.java
+++ b/src/main/java/com/example/autotest_backend/repository/QuestionRepository.java
@@ -1,0 +1,12 @@
+package com.example.autotest_backend.repository;
+
+import com.example.autotest_backend.model.Question;
+import com.example.autotest_backend.model.QuestionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    List<Question> findByStatus(QuestionStatus status);
+}

--- a/src/main/java/com/example/autotest_backend/repository/UserQuestionRepository.java
+++ b/src/main/java/com/example/autotest_backend/repository/UserQuestionRepository.java
@@ -1,0 +1,15 @@
+package com.example.autotest_backend.repository;
+
+import com.example.autotest_backend.model.Question;
+import com.example.autotest_backend.model.User;
+import com.example.autotest_backend.model.UserQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserQuestionRepository extends JpaRepository<UserQuestion, Long> {
+
+    boolean existsByUserAndQuestion(User user, Question question);
+
+    List<UserQuestion> findByUser(User user);
+}

--- a/src/main/java/com/example/autotest_backend/repository/UserRepository.java
+++ b/src/main/java/com/example/autotest_backend/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.example.autotest_backend.repository;
+
+import com.example.autotest_backend.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+}


### PR DESCRIPTION
# Pull Request

## Summary
<!-- Brief summary of changes introduced -->
This PR adds the JPA repositories for the core entities of the AutoTest MVP.

## Related Issue
<!-- Link the related issue, e.g., Closes #12 -->
Closes #2

## Changes
<!-- List the main changes made -->
- Added `UserRepository` with method to find user by email
- Added `QuestionRepository` with method to find questions by status
- Added `UserQuestionRepository` with methods to check if a question has been answered and to retrieve all questions by user
- Basic CRUD operations are provided by extending `JpaRepository`

## Design Decisions
<!-- Explain relevant design, architecture, or domain decisions -->
- `ChoiceRepository` is not needed for the MVP; `Choice` is managed via `Question` (cascade)
- Custom methods follow Spring Data JPA conventions for clarity and maintainability
- Repositories are designed to be simple but extendable for future metrics or additional filters

## Scope
<!-- What is included and what is not in this PR -->
Includes:
- Repository layer only
- Core JPA repositories for MVP

Excludes:
- Services
- Controllers
- Frontend integration

## Testing
<!-- How it was tested, if applicable -->
- Compilation succeeds

## Notes
<!-- Additional information, warnings, reminders -->
- Serves as the foundation for the service layer and backend logic
