### PR TITLE
feat: add service for core entities

### DIFF
--- a/src/main/java/com/example/autotest_backend/repository/UserRepository.java
+++ b/src/main/java/com/example/autotest_backend/repository/UserRepository.java
@@ -8,4 +8,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/autotest_backend/service/QuestionService.java
+++ b/src/main/java/com/example/autotest_backend/service/QuestionService.java
@@ -1,0 +1,16 @@
+package com.example.autotest_backend.service;
+
+import com.example.autotest_backend.model.Question;
+
+import java.util.List;
+
+public interface QuestionService {
+
+    Question createQuestion(Question question);
+
+    List<Question> getApprovedQuestions();
+
+    Question approveQuestion(Long questionId);
+
+    Question rejectQuestion(Long questionId);
+}

--- a/src/main/java/com/example/autotest_backend/service/QuestionServiceImpl.java
+++ b/src/main/java/com/example/autotest_backend/service/QuestionServiceImpl.java
@@ -1,0 +1,49 @@
+package com.example.autotest_backend.service;
+
+import com.example.autotest_backend.model.Question;
+import com.example.autotest_backend.model.QuestionStatus;
+import com.example.autotest_backend.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuestionServiceImpl implements QuestionService{
+
+    private final QuestionRepository questionRepository;
+
+
+    @Override
+    public Question createQuestion(Question question) {
+        return questionRepository.save(question);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Question> getApprovedQuestions() {
+        return questionRepository.findByStatus(QuestionStatus.APPROVED);
+    }
+
+    @Override
+    public Question approveQuestion(Long questionId) {
+        Question question = getQuestionOrThrow(questionId);
+        question.setStatus(QuestionStatus.APPROVED);
+        return question;
+    }
+
+    @Override
+    public Question rejectQuestion(Long questionId) {
+        Question question = getQuestionOrThrow(questionId);
+        question.setStatus(QuestionStatus.REJECTED);
+        return question;
+    }
+
+    private Question getQuestionOrThrow(Long id) {
+        return questionRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Question not found"));
+    }
+}

--- a/src/main/java/com/example/autotest_backend/service/QuestionServiceImpl.java
+++ b/src/main/java/com/example/autotest_backend/service/QuestionServiceImpl.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class QuestionServiceImpl implements QuestionService{
+public class QuestionServiceImpl implements QuestionService {
 
     private final QuestionRepository questionRepository;
 

--- a/src/main/java/com/example/autotest_backend/service/UserQuestionService.java
+++ b/src/main/java/com/example/autotest_backend/service/UserQuestionService.java
@@ -1,0 +1,20 @@
+package com.example.autotest_backend.service;
+
+import com.example.autotest_backend.model.Question;
+import com.example.autotest_backend.model.User;
+import com.example.autotest_backend.model.UserQuestion;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public interface UserQuestionService {
+
+    UserQuestion markAsCompleted(User user, Question question);
+
+    boolean hasUserCompletedQuestion(User user, Question question);
+
+    List<UserQuestion> getCompletedQuestionsByUser(User user);
+}

--- a/src/main/java/com/example/autotest_backend/service/UserQuestionService.java
+++ b/src/main/java/com/example/autotest_backend/service/UserQuestionService.java
@@ -3,13 +3,8 @@ package com.example.autotest_backend.service;
 import com.example.autotest_backend.model.Question;
 import com.example.autotest_backend.model.User;
 import com.example.autotest_backend.model.UserQuestion;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-
-@Service
-@Transactional
 public interface UserQuestionService {
 
     UserQuestion markAsCompleted(User user, Question question);

--- a/src/main/java/com/example/autotest_backend/service/UserQuestionServiceImpl.java
+++ b/src/main/java/com/example/autotest_backend/service/UserQuestionServiceImpl.java
@@ -4,14 +4,14 @@ import com.example.autotest_backend.model.Question;
 import com.example.autotest_backend.model.User;
 import com.example.autotest_backend.model.UserQuestion;
 import com.example.autotest_backend.repository.UserQuestionRepository;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Transactional
 public class UserQuestionServiceImpl implements UserQuestionService {
 

--- a/src/main/java/com/example/autotest_backend/service/UserQuestionServiceImpl.java
+++ b/src/main/java/com/example/autotest_backend/service/UserQuestionServiceImpl.java
@@ -1,0 +1,46 @@
+package com.example.autotest_backend.service;
+
+import com.example.autotest_backend.model.Question;
+import com.example.autotest_backend.model.User;
+import com.example.autotest_backend.model.UserQuestion;
+import com.example.autotest_backend.repository.UserQuestionRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class UserQuestionServiceImpl implements UserQuestionService{
+
+    private final UserQuestionRepository userQuestionRepository;
+
+    @Override
+    public UserQuestion markAsCompleted(User user, Question question) {
+
+        if (userQuestionRepository.existsByUserAndQuestion(user, question)) {
+            throw new IllegalStateException("Question already completed by user");
+        }
+
+        UserQuestion userQuestion = UserQuestion.builder()
+                .user(user)
+                .question(question)
+                .build();
+
+        return userQuestionRepository.save(userQuestion);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasUserCompletedQuestion(User user, Question question) {
+        return userQuestionRepository.existsByUserAndQuestion(user, question);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<UserQuestion> getCompletedQuestionsByUser(User user) {
+        return userQuestionRepository.findByUser(user);
+    }
+}

--- a/src/main/java/com/example/autotest_backend/service/UserQuestionServiceImpl.java
+++ b/src/main/java/com/example/autotest_backend/service/UserQuestionServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.autotest_backend.model.User;
 import com.example.autotest_backend.model.UserQuestion;
 import com.example.autotest_backend.repository.UserQuestionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,17 +20,17 @@ public class UserQuestionServiceImpl implements UserQuestionService {
 
     @Override
     public UserQuestion markAsCompleted(User user, Question question) {
+        try {
+            UserQuestion uq = UserQuestion.builder()
+                    .user(user)
+                    .question(question)
+                    .build();
 
-        if (userQuestionRepository.existsByUserAndQuestion(user, question)) {
+            return userQuestionRepository.save(uq);
+
+        } catch (DataIntegrityViolationException ex) {
             throw new IllegalStateException("Question already completed by user");
         }
-
-        UserQuestion userQuestion = UserQuestion.builder()
-                .user(user)
-                .question(question)
-                .build();
-
-        return userQuestionRepository.save(userQuestion);
     }
 
     @Override

--- a/src/main/java/com/example/autotest_backend/service/UserQuestionServiceImpl.java
+++ b/src/main/java/com/example/autotest_backend/service/UserQuestionServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Service
 @AllArgsConstructor
 @Transactional
-public class UserQuestionServiceImpl implements UserQuestionService{
+public class UserQuestionServiceImpl implements UserQuestionService {
 
     private final UserQuestionRepository userQuestionRepository;
 

--- a/src/main/java/com/example/autotest_backend/service/UserService.java
+++ b/src/main/java/com/example/autotest_backend/service/UserService.java
@@ -1,0 +1,16 @@
+package com.example.autotest_backend.service;
+
+import com.example.autotest_backend.model.User;
+
+import java.util.Optional;
+
+public interface UserService {
+
+    Optional<User> getUserById(Long id);
+
+    Optional<User> getUserByEmail(String email);
+
+    boolean existsByEmail(String email);
+
+    User createUserIfNotExists(String email);
+}

--- a/src/main/java/com/example/autotest_backend/service/UserServiceImpl.java
+++ b/src/main/java/com/example/autotest_backend/service/UserServiceImpl.java
@@ -29,6 +29,7 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
+    @Transactional(readOnly = true)
     public boolean existsByEmail(String email) {
         return userRepository.existsByEmail(email);
     }

--- a/src/main/java/com/example/autotest_backend/service/UserServiceImpl.java
+++ b/src/main/java/com/example/autotest_backend/service/UserServiceImpl.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class UserServiceImpl implements UserService{
+public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
 

--- a/src/main/java/com/example/autotest_backend/service/UserServiceImpl.java
+++ b/src/main/java/com/example/autotest_backend/service/UserServiceImpl.java
@@ -1,0 +1,46 @@
+package com.example.autotest_backend.service;
+
+import com.example.autotest_backend.model.User;
+import com.example.autotest_backend.model.UserRole;
+import com.example.autotest_backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<User> getUserById(Long id) {
+        return userRepository.findById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<User> getUserByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    @Override
+    public User createUserIfNotExists(String email) {
+        return userRepository.findByEmail(email)
+                .orElseGet(() -> userRepository.save(
+                        User.builder()
+                                .email(email)
+                                .role(UserRole.STUDENT) //default
+                                .build()
+                ));
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary
This PR introduces the core service layer for the AutoTest MVP. It includes services to manage users, questions, and the association of completed questions by users.

## Related Issue
Closes #5 

## Changes
- Added `UserService` and `UserServiceImpl` to manage users.
- Added `QuestionService` and `QuestionServiceImpl` to manage questions.
- Added `UserQuestionService` and `UserQuestionServiceImpl` to track completed questions by users.
- Implemented methods for:
  - Marking questions as completed
  - Checking if a question has been completed by a user
  - Retrieving all completed questions for a user
- Ensured transactional integrity and proper use of JPA repositories.

## Design Decisions
- `UserQuestion` only stores completed questions; no attribute for correctness is needed.
- Service methods receive entity objects (`User` and `Question`) instead of IDs to leverage JPA relationships and the persistence context.
- Methods are transactional, with read-only transactions for query operations.
- `UserQuestionService` ensures that a question cannot be marked as completed twice for the same user.
- Prepared for future extensions, e.g., adding attempts, metrics, or batch operations.

## Scope
Includes the service layer for the MVP:
- Service interfaces
- Service implementations
- Core business logic for users, questions, and completed questions

Does not include:
- Controllers
- DTOs or mapping
- Frontend integration

## Testing
- Compilation successful

## Notes
- This PR sets the foundation for the controller layer and API endpoints.
- The domain language uses `completed` to indicate questions successfully answered by a user.
